### PR TITLE
Remove pesudo-field contentDescription and its use in Poll view.

### DIFF
--- a/Products/PlonePopoll/content/PlonePopoll.py
+++ b/Products/PlonePopoll/content/PlonePopoll.py
@@ -82,11 +82,6 @@ class PlonePopoll(atct.ATCTContent):
         "Returns the description of the poll, which is in fact the question"
         return self.getQuestion()
 
-    security.declareProtected(permissions.View, 'contentDescription')
-    def contentDescription(self):
-        "Returns the description of the poll, which is in fact the question"
-        return self.getField('description').get(self)
-
     security.declareProtected(permissions.View, 'getVoteId')
     def getVoteId(self):
         """ return unique vote id """

--- a/Products/PlonePopoll/skins/PlonePopoll/plonepopoll_view.pt
+++ b/Products/PlonePopoll/skins/PlonePopoll/plonepopoll_view.pt
@@ -9,10 +9,6 @@
 <body>
 
 <metal:content-description fill-slot="content-description">
-  <p class="documentDescription" tal:condition="context/contentDescription"
-     tal:content="context/contentDescription">
-      Poll description (the real one)
-  </p>
 </metal:content-description>
 
 <metal:content-core fill-slot="content-core">

--- a/Products/PlonePopoll/skins/PlonePopoll/plonepopoll_view.pt
+++ b/Products/PlonePopoll/skins/PlonePopoll/plonepopoll_view.pt
@@ -24,7 +24,7 @@
            tal:content="context/Description">
               This is the question
         </p>
-        
+
         <p tal:condition="python:not canVote and not hasVoted"
            i18n:translate="description_cant_vote">
           You can't vote for this poll.
@@ -37,12 +37,12 @@
            i18n:translate="description_vote">
           You can vote at most for <span i18n:name="number" tal:replace="number">#</span> choice(s) on the poll. If you vote again, your old vote is replaced by the new vote.
         </p>
-    
+
         <p i18n:translate="text_not_enable"
            tal:condition="not: context/isEnabled">
           The poll is not enabled.
         </p>
-    
+
         <form class="group"
               name="results"
               action=""
@@ -50,7 +50,7 @@
               enctype="multipart/form-data"
               tal:define="object_url python:here.absolute_url();"
               tal:attributes="action string:${object_url}/vote">
-    
+
           <fieldset>
             <ul>
             <li tal:repeat="choice here/getResults">
@@ -71,20 +71,20 @@
                    num repeat/choice/number;
                                num python:num % 10">
                   <img height="10" tal:attributes="width string:${bar_percentage}; src string:${portal_url}/bar_${num}.gif; alt string:${choice_percentage}%" />
-    
+
                   <span tal:content="structure string:${choice_count} (${choice_percentage}%)">150 (14%)</span>
                 </tal:block>
               </div>
             </li>
             </ul>
           </fieldset>
-    
+
           <div class="field"
                tal:define="vote_count python:here.getVotesCount()">
             <fieldset>
-    
+
               <legend i18n:translate="legend_total_votes">Total votes</legend>
-    
+
               <div i18n:translate="text_votes_count">
                 <span i18n:name="vote_count" tal:content="structure string:${vote_count}">
                   people have voted on this poll.
@@ -98,7 +98,7 @@
               </div>
             </fieldset>
           </div>
-    
+
           <div class="formControls">
             <input class="context"
                    type="submit"

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -3,6 +3,10 @@ Changelog
 
 2.8b2 (unreleased)
 ------------------
+
+- Remove pseudo-field ``contentDescription`` and its use in Poll view.
+  [khink]
+
 - Fix a selection bug when your choice is greater than 10.
   [boulch]
 

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -3,35 +3,35 @@ Changelog
 
 2.8b2 (unreleased)
 ------------------
-- Fix a selection bug when your choice is greater than 10. 
+- Fix a selection bug when your choice is greater than 10.
   [boulch]
 
-- Add minimal buildout 
+- Add minimal buildout
   [bsuttor]
 
-- Include permission from Products.CMFCore for fixing zcml error 
+- Include permission from Products.CMFCore for fixing zcml error
   [bsuttor]
 
-- Accessibility fix: text node replaced with HTML label 
+- Accessibility fix: text node replaced with HTML label
   [keul]
 
 - Do not raise Unauthorized error anymore is user can see
-  the Poll but not vote 
+  the Poll but not vote
   [keul]
 
-- Description field is now displayed 
-  [keul] 
-
-- Do not filter Popoll in portlet for anonymous (close `#1`__) 
-  [micecchi, keul] 
-
-- Some additional user messages in the Poll view 
+- Description field is now displayed
   [keul]
 
-- Restored natural Plone order for field in the Poll view 
+- Do not filter Popoll in portlet for anonymous (close `#1`__)
+  [micecchi, keul]
+
+- Some additional user messages in the Poll view
   [keul]
 
-- Fixed Poll view for Plone 4 compatibility 
+- Restored natural Plone order for field in the Poll view
+  [keul]
+
+- Fixed Poll view for Plone 4 compatibility
   [cekk]
 
 __ https://github.com/collective/Products.PlonePopoll/issues/1


### PR DESCRIPTION
This made the poll question appear twice in the Poll view.

contentDescription is not used anywhere else in the code, and is not something the class needs to provide.

I think it's safe to remove it altogether.